### PR TITLE
feat: Add Export as .txt file option

### DIFF
--- a/backend/src/controllers/exportController.ts
+++ b/backend/src/controllers/exportController.ts
@@ -21,8 +21,12 @@ export const handleExport = async (req: Request, res: Response) => {
             buffer = await generateDocxBuffer(text);
             contentType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
             extension = 'docx';
+        } else if (format === 'txt') {
+            buffer = Buffer.from(text, 'utf-8');
+            contentType = 'text/plain';
+            extension = 'txt';
         } else {
-            return res.status(400).json({ error: 'Invalid export format. Use "pdf" or "docx".' });
+            return res.status(400).json({ error: 'Invalid export format. Use "pdf", "docx", or "txt".' });
         }
 
         const downloadName = `${fileName || 'humanized_text'}.${extension}`;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -177,7 +177,7 @@ function App() {
         setTimeout(() => setCopySuccess(false), 2000);
     };
 
-    const handleExport = async (format: 'pdf' | 'docx') => {
+    const handleExport = async (format: 'pdf' | 'docx' | 'txt') => {
         if (!humanizedText) {
             alert('Please generate content first before exporting.');
             return;
@@ -400,10 +400,17 @@ function App() {
                                     </button>
                                     <button
                                         onClick={() => handleExport('docx')}
-                                        className="flex items-center gap-2 px-4 py-2 text-xs font-bold text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-all active:scale-95"
+                                        className="flex items-center gap-2 px-4 py-2 text-xs font-bold text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-all border-r border-slate-100 active:scale-95"
                                     >
                                         <FileText size={14} />
                                         Export DOCX
+                                    </button>
+                                    <button
+                                        onClick={() => handleExport('txt')}
+                                        className="flex items-center gap-2 px-4 py-2 text-xs font-bold text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-all active:scale-95"
+                                    >
+                                        <FileText size={14} />
+                                        Export TXT
                                     </button>
                                 </div>
                                 <button 


### PR DESCRIPTION
Add TXT export option alongside PDF and DOCX.

Backend: Added txt format handling with text/plain content type
Frontend: Added Export TXT button and updated handleExport

Fixes: #5