### PR TITLE
fix(ui): improve responsive sidebar for tablet screens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,11 +81,19 @@ function App() {
     }, []);
 
     useEffect(() => {
-        const handleResize = () => {
-            setIsSidebarCollapsed(window.innerWidth >= 768 && window.innerWidth < 1024);
-        };
-        window.addEventListener('resize', handleResize);
+    const handleResize = () => {
+        const isTablet = window.innerWidth >= 768 && window.innerWidth < 1024;
+        const isDesktop = window.innerWidth >= 1024;
+        if (isTablet) {
+            setIsSidebarCollapsed(true);
+        } else if (isDesktop) {
+            setIsSidebarCollapsed(false);
+        }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
     }, []);
+    
     const fetchProfile = async (token: string) => {
         try {
             const response = await axios.get('http://localhost:5000/api/auth/profile', {
@@ -269,7 +277,7 @@ function App() {
                 <motion.aside 
                     initial={false}
                     animate={{ width: isSidebarCollapsed ? 72 : 256 }}
-                    transition={{ duration: 0.3, ease: 'easeout' }}
+                    transition={{ duration: 0.3, ease: 'easeInOut' }}
                     className="glass border-r border-slate-200/50 flex flex-col p-6 hidden md:flex z-20 overflow-hidden relative"
                 >
                     <div className={`flex items-center ${isSidebarCollapsed ? 'justify-center' : 'justify-between'} mb-10`}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,9 @@ function App() {
     const [processStatus, setProcessStatus] = useState<'idle' | 'analyzing' | 'rewriting' | 'detecting'>('idle');
     const [copySuccess, setCopySuccess] = useState(false);
     const [isRefineMenuOpen, setIsRefineMenuOpen] = useState(false);
-    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(
+        window.innerWidth >= 768 && window.innerWidth < 1024
+    );
 
     const getPlaceholder = () => {
         if (!selectedTool) return "Paste text or drag & drop .pdf, .docx, .txt files here...";
@@ -78,6 +80,12 @@ function App() {
         }
     }, []);
 
+    useEffect(() => {
+        const handleResize = () => {
+            setIsSidebarCollapsed(window.innerWidth >= 768 && window.innerWidth < 1024);
+        };
+        window.addEventListener('resize', handleResize);
+    }, []);
     const fetchProfile = async (token: string) => {
         try {
             const response = await axios.get('http://localhost:5000/api/auth/profile', {
@@ -260,7 +268,8 @@ function App() {
             {view !== 'landing' && (
                 <motion.aside 
                     initial={false}
-                    animate={{ width: isSidebarCollapsed ? 80 : 256 }}
+                    animate={{ width: isSidebarCollapsed ? 72 : 256 }}
+                    transition={{ duration: 0.3, ease: 'easeout' }}
                     className="glass border-r border-slate-200/50 flex flex-col p-6 hidden md:flex z-20 overflow-hidden relative"
                 >
                     <div className={`flex items-center ${isSidebarCollapsed ? 'justify-center' : 'justify-between'} mb-10`}>


### PR DESCRIPTION
## 🔍 What's changed?
Improved sidebar responsiveness for tablet screens (768px-1024px). 
The sidebar now auto-collapses to icon-only view on tablets, adds a 
smooth resize listener for dynamic updates, and uses easeInOut 
transition for a more premium feel.

## 🚀 Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have checked that my PR doesn't break any existing functionalities.
- [x] I have linked the issue this PR resolves (Closes #7)

## 📸 Screenshots (if applicable)
<img width="1512" height="803" alt="image" src="https://github.com/user-attachments/assets/c4b4be18-c924-4f66-89cc-81702049a653" />
<img width="1512" height="803" alt="image" src="https://github.com/user-attachments/assets/4d7b20ca-6b47-445c-b467-ad6047d63aec" />


## 📝 Additional notes
Tested on desktop (1024px+), tablet (900px), and mobile (320px). 
Only App.tsx was modified — no other files touched.

---
*GSSoC 2026 Contributor* ✨
